### PR TITLE
Add Authorization header in to request with override and custom endpoint of Moya

### DIFF
--- a/Nimble-Code-Challenge/Shared/Constants/AppConstants.swift
+++ b/Nimble-Code-Challenge/Shared/Constants/AppConstants.swift
@@ -14,4 +14,9 @@ struct AppConstants {
     static let clientSecret: String = AppConfigurationHelper.shared.value(for: "CLIENT_SECRET") ?? ""
     static let clientId: String = AppConfigurationHelper.shared.value(for: "CLIENT_ID") ?? ""
     
+    struct URL {
+        static let authen = "oath/token"
+        static let surveys = "surveys"
+    }
+    
 }

--- a/Nimble-Code-Challenge/Shared/Network/Auth/AuthAPI+TargetType.swift
+++ b/Nimble-Code-Challenge/Shared/Network/Auth/AuthAPI+TargetType.swift
@@ -13,7 +13,7 @@ extension AuthAPI: TargetType {
     }
     
     var path: String {
-        return "oauth/token"
+        return AppConstants.URL.authen
     }
     
     var method: Moya.Method {

--- a/Nimble-Code-Challenge/Shared/Network/BaseProvider.swift
+++ b/Nimble-Code-Challenge/Shared/Network/BaseProvider.swift
@@ -18,10 +18,22 @@ private var apiSession: Session = {
 }()
 
 class BaseProvider<API: TargetType>: MoyaProvider<API> {
+    
+    override func endpoint(_ token: API) -> Endpoint {
+        let defaultEndpoint = MoyaProvider.defaultEndpointMapping(for: token)
+        if !defaultEndpoint.url.contains(AppConstants.URL.authen) {
+            let credential = UserSession.shared.getCredential()
+            if !credential.attributes.access_token.isEmpty {
+                let authorizationHeader = "\(credential.attributes.token_type) \(credential.attributes.access_token)"
+                return defaultEndpoint.adding(newHTTPHeaderFields: ["Authorization": authorizationHeader])
+            }
+        }
+        return defaultEndpoint
+    }
+    
     convenience init(apiSession: Session = apiSession,
                      pluginsProvider: [PluginType] = []) {
-        self.init(endpointClosure: MoyaProvider.defaultEndpointMapping,
-                  requestClosure: MoyaProvider<API>.defaultRequestMapping,
+        self.init(requestClosure: MoyaProvider<API>.defaultRequestMapping,
                   stubClosure: MoyaProvider.neverStub,
                   callbackQueue: nil,
                   session: apiSession,

--- a/Nimble-Code-Challenge/Shared/Network/Nimble/NimbleSurveyAPI+TargetType.swift
+++ b/Nimble-Code-Challenge/Shared/Network/Nimble/NimbleSurveyAPI+TargetType.swift
@@ -15,11 +15,11 @@ extension NimbleSurveyAPI: TargetType {
     var path: String {
         switch self {
         case .login:
-            return "oauth/token"
+            return AppConstants.URL.authen
         case .surveys:
-            return "surveys"
+            return AppConstants.URL.surveys
         case .surveyDetail(let id):
-            return "surveys/\(id)"
+            return "\(AppConstants.URL.surveys)/\(id)"
         }
     }
     
@@ -41,10 +41,10 @@ extension NimbleSurveyAPI: TargetType {
             paramaters["grant_type"] = "password"
             paramaters["email"] = email
             paramaters["password"] = password
-        case .surveys, .surveyDetail:
+            return paramaters
+        default:
             return paramaters
         }
-        return paramaters
     }
     
     var parameterEncoding: ParameterEncoding {
@@ -56,17 +56,7 @@ extension NimbleSurveyAPI: TargetType {
     }
     
     var headers: [String: String]? {
-        var headers: [String: String] = [:]
-        switch self {
-        case .login:
-            return headers
-        default:
-            let credential = UserSession.shared.getCredential()
-            if !credential.attributes.access_token.isEmpty {
-                headers["Authorization"] = "\(credential.attributes.token_type) \(credential.attributes.access_token)"
-            }
-        }
-        return headers
+        return [:]
     }
     
 }


### PR DESCRIPTION
This pull request is for issue #34 .

Custom the `endpoint` of MoyaProvider when it's creating a request to the backend and set the header at that moment.